### PR TITLE
Run Markdoc on Replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nix"
+run = "npm run dev"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ The quickest way to deploy your own version of this boilerplate is by deploying 
 ### Deploy to Netlify
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/next.js-starter)
+
+### Run on Replit
+
+[![Run on Repl.it](https://repl.it/badge/github/markdoc/next.js-starter)](https://repl.it/github/markdoc/next.js-starter)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can start editing the page by modifying `index.md`. The page auto-updates as
 
 ## Deploy
 
-The quickest way to deploy your own version of this boilerplate is by deploying it with [Vercel](https://vercel.com) or [Netlify](https://www.netlify.com/) by clicking one of the buttons below.
+The quickest way to deploy your own version of this boilerplate is by deploying it with [Vercel](https://vercel.com), [Netlify](https://www.netlify.com/), or [Replit](https://replit.com/) by clicking one of the buttons below.
 
 ### Deploy with Vercel
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -9,9 +9,11 @@ This website is a lightweight boilerplate to spin up a documentation website wit
 
 ## Quick start
 
-If you want to get started right away with this boilerplate, either clone the [GitHub repository](https://github.com/markdoc/next.js-starter) or deploy a version of this site to Vercel by clicking the button below.
+If you want to get started right away with this boilerplate, either clone the [GitHub repository](https://github.com/markdoc/next.js-starter) or deploy a version of this site to Vercel or Replit by clicking the buttons below.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/next.js-starter)
+
+[![Run on Repl.it](https://repl.it/badge/github/markdoc/next.js-starter)](https://repl.it/github/markdoc/next.js-starter)
 
 ## Get started from scratch
 

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+    deps = [
+        pkgs.nodejs-16_x
+    ];
+}


### PR DESCRIPTION
Hey! 
I'm with @replit and we're super excited about markdoc. I've been stoked for its public release ever since I saw the initial tech demo by @segphault. Replit seems like a great place to run markdoc and we've been looking for something like it for our internal docs, too. I've set up a template for the next.js starter on replit [here](https://replit.com/@TalorAnderson/markdoc-with-nextjs-starter#pages/index.md) so folks on our platform can easily jump in to using markdoc, and you can see the live version [here](https://markdoc-with-nextjs-starter.taloranderson.repl.co). 

## This PR adds:
- `.replit` - config file that tells replit how to run the project
- `replit.nix` - nix file config 
- updates README.md and pages/index.md to include "run on replit" badges

